### PR TITLE
Fix: PriorWD inadvertently sets the weight_decay coefficient for all groups to 0.0 when use_prior_wd flag is False

### DIFF
--- a/prior_wd_optim.py
+++ b/prior_wd_optim.py
@@ -12,15 +12,16 @@ class PriorWD(Optimizer):
         self.use_prior_wd = use_prior_wd
         self.exclude_last_group = exclude_last_group
 
-        self.weight_decay_by_group = []
-        for i, group in enumerate(self.param_groups):
-            self.weight_decay_by_group.append(group["weight_decay"])
-            group["weight_decay"] = 0
+        if use_prior_wd:
+            self.weight_decay_by_group = []
+            for i, group in enumerate(self.param_groups):
+                self.weight_decay_by_group.append(group["weight_decay"])
+                group["weight_decay"] = 0
 
-        self.prior_params = {}
-        for i, group in enumerate(self.param_groups):
-            for p in group["params"]:
-                self.prior_params[id(p)] = p.detach().clone()
+            self.prior_params = {}
+            for i, group in enumerate(self.param_groups):
+                for p in group["params"]:
+                    self.prior_params[id(p)] = p.detach().clone()
 
     def step(self, closure=None):
         if self.use_prior_wd:


### PR DESCRIPTION
Probably don't need to merge this, but can serve as a reference for people who fork the repo.

### Problem

The PriorWD is wrapper around any optimizer which can be used to perform weight decay by suppressing `||w - w_0||^2` instead of `||w - 0||^2` during training. 

```
optimizer = optim.AdamW(self.parameters(), lr=1e-3, weight_decay=0.01)
optimizer = PriorWD(optimizer, use_prior_wd=True)
```

When `use_prior_wd` is set to `True`, the class behaves as expected. When it is set to `False`, the wrapper needs to function as an Identity mapping on the optimizer, but it inadvertently sets the weight decay to `0.0`.

This was fixed by simply adding a conditional statement with use_prior_wd flag during initialization.  
